### PR TITLE
Simplify list-randomizer: render_block_data, hide from inserter

### DIFF
--- a/blocks-randomizer.php
+++ b/blocks-randomizer.php
@@ -59,3 +59,9 @@ function blocks_randomizer_block_init() {
 }
 
 add_action( 'init', 'blocks_randomizer_block_init' );
+
+/**
+ * Include the server-side rendering for List block randomization.
+ * This adds the render_block filter to randomize list items when the randomize attribute is enabled.
+ */
+require_once __DIR__ . '/build/list-randomizer/render.php';

--- a/blocks-randomizer.php
+++ b/blocks-randomizer.php
@@ -64,4 +64,7 @@ add_action( 'init', 'blocks_randomizer_block_init' );
  * Include the server-side rendering for List block randomization.
  * This adds the render_block filter to randomize list items when the randomize attribute is enabled.
  */
-require_once __DIR__ . '/build/list-randomizer/render.php';
+$list_randomizer_render_file = __DIR__ . '/build/list-randomizer/render.php';
+if ( file_exists( $list_randomizer_render_file ) ) {
+	require_once $list_randomizer_render_file;
+}

--- a/blocks-randomizer.php
+++ b/blocks-randomizer.php
@@ -61,8 +61,9 @@ function blocks_randomizer_block_init() {
 add_action( 'init', 'blocks_randomizer_block_init' );
 
 /**
- * Include the server-side rendering for List block randomization.
- * This adds the render_block filter to randomize list items when the randomize attribute is enabled.
+ * Include the server-side randomization logic for the core/list block.
+ * The file registers a render_block_data filter; it is not a block render callback,
+ * so it is not referenced from block.json and must be loaded manually.
  */
 $list_randomizer_render_file = __DIR__ . '/build/list-randomizer/render.php';
 if ( file_exists( $list_randomizer_render_file ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15079,7 +15079,6 @@
 			"integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.6",
 				"ajv-errors": "^1.0.1",
@@ -19974,7 +19973,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -20219,7 +20217,6 @@
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -20456,7 +20453,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.3.0"
 			},
@@ -20893,7 +20889,6 @@
 			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^2.1.1",
@@ -20974,7 +20969,6 @@
 			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/bonjour": "^3.5.9",
 				"@types/connect-history-api-fallback": "^1.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15079,6 +15079,7 @@
 			"integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.6",
 				"ajv-errors": "^1.0.1",
@@ -19973,6 +19974,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -20217,6 +20219,7 @@
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -20453,6 +20456,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.3.0"
 			},
@@ -20889,6 +20893,7 @@
 			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^2.1.1",
@@ -20969,6 +20974,7 @@
 			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/bonjour": "^3.5.9",
 				"@types/connect-history-api-fallback": "^1.3.5",

--- a/src/list-randomizer/block.json
+++ b/src/list-randomizer/block.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "blocks-randomizer/list-randomizer",
+	"version": "1.3.0",
+	"title": "List Randomizer Extension",
+	"category": "widgets",
+	"description": "Extends core/list block with randomization capability.",
+	"textdomain": "blocks-randomizer",
+	"editorScript": "file:./index.js",
+	"render": "file:./render.php"
+}

--- a/src/list-randomizer/block.json
+++ b/src/list-randomizer/block.json
@@ -5,8 +5,10 @@
 	"version": "1.3.0",
 	"title": "List Randomizer Extension",
 	"category": "widgets",
-	"description": "Extends core/list block with randomization capability.",
+	"description": "Extends core/list block with a Randomize toggle (not insertable; editor-only extension).",
+	"supports": {
+		"inserter": false
+	},
 	"textdomain": "blocks-randomizer",
-	"editorScript": "file:./index.js",
-	"render": "file:./render.php"
+	"editorScript": "file:./index.js"
 }

--- a/src/list-randomizer/index.js
+++ b/src/list-randomizer/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { ToggleControl } from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -57,7 +57,10 @@ const withRandomizeControl = createHigherOrderComponent( ( BlockEdit ) => {
 			<>
 				<BlockEdit { ...props } />
 				<InspectorControls>
-					<div style={ { padding: '16px' } }>
+					<PanelBody
+						title={ __( 'Randomization', 'blocks-randomizer' ) }
+						initialOpen={ false }
+					>
 						<ToggleControl
 							label={ __( 'Randomize', 'blocks-randomizer' ) }
 							help={ __(
@@ -69,7 +72,7 @@ const withRandomizeControl = createHigherOrderComponent( ( BlockEdit ) => {
 								setAttributes( { randomize: value } )
 							}
 						/>
-					</div>
+					</PanelBody>
 				</InspectorControls>
 			</>
 		);

--- a/src/list-randomizer/index.js
+++ b/src/list-randomizer/index.js
@@ -1,0 +1,109 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { ToggleControl } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/block-editor';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Add randomize attribute to core/list block.
+ *
+ * @param {Object} settings Block settings.
+ * @param {string} name     Block name.
+ * @return {Object} Modified block settings.
+ */
+function addRandomizeAttribute( settings, name ) {
+	if ( name !== 'core/list' ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		attributes: {
+			...settings.attributes,
+			randomize: {
+				type: 'boolean',
+				default: false,
+			},
+		},
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'blocks-randomizer/list-randomizer/add-randomize-attribute',
+	addRandomizeAttribute
+);
+
+/**
+ * Add toggle control to core/list block inspector.
+ *
+ * @param {Function} BlockEdit Original BlockEdit component.
+ * @return {Function} Modified BlockEdit component.
+ */
+const withRandomizeControl = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		const { name, attributes, setAttributes } = props;
+
+		if ( name !== 'core/list' ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const { randomize } = attributes;
+
+		return (
+			<>
+				<BlockEdit { ...props } />
+				<InspectorControls>
+					<div style={ { padding: '16px' } }>
+						<ToggleControl
+							label={ __( 'Randomize', 'blocks-randomizer' ) }
+							help={ __(
+								'Randomize the order of list items on each page load.',
+								'blocks-randomizer'
+							) }
+							checked={ randomize || false }
+							onChange={ ( value ) =>
+								setAttributes( { randomize: value } )
+							}
+						/>
+					</div>
+				</InspectorControls>
+			</>
+		);
+	};
+}, 'withRandomizeControl' );
+
+addFilter(
+	'editor.BlockEdit',
+	'blocks-randomizer/list-randomizer/with-randomize-control',
+	withRandomizeControl
+);
+
+/**
+ * Add randomize attribute to block save content.
+ *
+ * @param {Object} extraProps Additional props for the block.
+ * @param {Object} blockType  Block type definition.
+ * @param {Object} attributes Block attributes.
+ * @return {Object} Modified extraProps.
+ */
+function saveRandomizeAttribute( extraProps, blockType, attributes ) {
+	if ( blockType.name !== 'core/list' ) {
+		return extraProps;
+	}
+
+	if ( attributes.randomize ) {
+		extraProps[ 'data-randomize' ] = 'true';
+	}
+
+	return extraProps;
+}
+
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'blocks-randomizer/list-randomizer/save-randomize-attribute',
+	saveRandomizeAttribute
+);

--- a/src/list-randomizer/index.js
+++ b/src/list-randomizer/index.js
@@ -1,5 +1,6 @@
 /**
- * WordPress dependencies
+ * Extends the core/list block with a "Randomize" toggle that shuffles
+ * list items on each server-side render.
  */
 import { addFilter } from '@wordpress/hooks';
 import { PanelBody, ToggleControl } from '@wordpress/components';
@@ -7,13 +8,6 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Add randomize attribute to core/list block.
- *
- * @param {Object} settings Block settings.
- * @param {string} name     Block name.
- * @return {Object} Modified block settings.
- */
 function addRandomizeAttribute( settings, name ) {
 	if ( name !== 'core/list' ) {
 		return settings;
@@ -37,12 +31,6 @@ addFilter(
 	addRandomizeAttribute
 );
 
-/**
- * Add toggle control to core/list block inspector.
- *
- * @param {Function} BlockEdit Original BlockEdit component.
- * @return {Function} Modified BlockEdit component.
- */
 const withRandomizeControl = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props ) => {
 		const { name, attributes, setAttributes } = props;
@@ -64,10 +52,10 @@ const withRandomizeControl = createHigherOrderComponent( ( BlockEdit ) => {
 						<ToggleControl
 							label={ __( 'Randomize', 'blocks-randomizer' ) }
 							help={ __(
-								'Randomize the order of list items on each page load.',
+								'Shuffle list items on each page load. Note: with full-page caching, the order changes only when the cache is regenerated.',
 								'blocks-randomizer'
 							) }
-							checked={ randomize || false }
+							checked={ randomize }
 							onChange={ ( value ) =>
 								setAttributes( { randomize: value } )
 							}
@@ -83,30 +71,4 @@ addFilter(
 	'editor.BlockEdit',
 	'blocks-randomizer/list-randomizer/with-randomize-control',
 	withRandomizeControl
-);
-
-/**
- * Add randomize attribute to block save content.
- *
- * @param {Object} extraProps Additional props for the block.
- * @param {Object} blockType  Block type definition.
- * @param {Object} attributes Block attributes.
- * @return {Object} Modified extraProps.
- */
-function saveRandomizeAttribute( extraProps, blockType, attributes ) {
-	if ( blockType.name !== 'core/list' ) {
-		return extraProps;
-	}
-
-	if ( attributes.randomize ) {
-		extraProps[ 'data-randomize' ] = 'true';
-	}
-
-	return extraProps;
-}
-
-addFilter(
-	'blocks.getSaveContent.extraProps',
-	'blocks-randomizer/list-randomizer/save-randomize-attribute',
-	saveRandomizeAttribute
 );

--- a/src/list-randomizer/render.php
+++ b/src/list-randomizer/render.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Server-side rendering for List block randomization.
+ *
+ * This file adds a render callback filter to the core/list block
+ * to randomize list items when the randomize attribute is enabled.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Filter the rendered output of the core/list block to randomize list items.
+ *
+ * @param string   $block_content The block content.
+ * @param array    $block         The full block, including name and attributes.
+ * @param WP_Block $instance      The block instance.
+ *
+ * @return string The modified block content.
+ */
+function blocks_randomizer_list_render_callback( $block_content, $block, $instance ) {
+	// Only process core/list blocks.
+	if ( 'core/list' !== $block['blockName'] ) {
+		return $block_content;
+	}
+
+	// Check if randomize attribute is enabled.
+	$randomize = isset( $block['attrs']['randomize'] ) && $block['attrs']['randomize'];
+
+	if ( ! $randomize ) {
+		return $block_content;
+	}
+
+	// Parse the HTML content to find list items.
+	$dom = new DOMDocument();
+	// Suppress warnings for malformed HTML.
+	libxml_use_internal_errors( true );
+	
+	// Load HTML with UTF-8 encoding.
+	$dom->loadHTML( '<?xml encoding="UTF-8">' . $block_content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+	
+	// Clear any errors.
+	libxml_clear_errors();
+
+	// Find the list element (ul or ol).
+	$xpath = new DOMXPath( $dom );
+	$lists = $xpath->query( '//ul | //ol' );
+
+	if ( $lists->length === 0 ) {
+		return $block_content;
+	}
+
+	// Process each list (usually just one).
+	foreach ( $lists as $list ) {
+		// Get all direct li children.
+		$list_items = array();
+		foreach ( $list->childNodes as $child ) {
+			if ( $child->nodeType === XML_ELEMENT_NODE && $child->nodeName === 'li' ) {
+				$list_items[] = $child;
+			}
+		}
+
+		// If we have list items, randomize them.
+		if ( count( $list_items ) > 1 ) {
+			// Remove all list items from the list.
+			foreach ( $list_items as $item ) {
+				$list->removeChild( $item );
+			}
+
+			// Shuffle the list items array.
+			shuffle( $list_items );
+
+			// Re-append the list items in random order.
+			foreach ( $list_items as $item ) {
+				$list->appendChild( $item );
+			}
+		}
+	}
+
+	// Save the modified HTML.
+	$modified_content = $dom->saveHTML();
+	
+	// Remove the XML encoding declaration that was added.
+	$modified_content = str_replace( '<?xml encoding="UTF-8">', '', $modified_content );
+
+	return $modified_content;
+}
+
+add_filter( 'render_block', 'blocks_randomizer_list_render_callback', 10, 3 );

--- a/src/list-randomizer/render.php
+++ b/src/list-randomizer/render.php
@@ -33,6 +33,8 @@ function blocks_randomizer_list_render_callback( $block_content, $block, $instan
 	}
 
 	// Parse the HTML content to find list items.
+	// Note: The block content comes from the WordPress database and has already been
+	// sanitized during block saving, so it's safe to parse here.
 	$dom = new DOMDocument();
 	// Suppress warnings for malformed HTML.
 	libxml_use_internal_errors( true );

--- a/src/list-randomizer/render.php
+++ b/src/list-randomizer/render.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Server-side rendering for List block randomization.
+ * Server-side randomization for the core/list block.
  *
- * This file adds a render callback filter to the core/list block
- * to randomize list items when the randomize attribute is enabled.
+ * Hooks `render_block_data` and shuffles the inner list-item blocks before
+ * rendering. This avoids HTML parsing entirely and works for the modern
+ * (v2) list block where list items are inner blocks.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -11,82 +12,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Filter the rendered output of the core/list block to randomize list items.
+ * Shuffle core/list inner blocks when the randomize attribute is set.
  *
- * @param string   $block_content The block content.
- * @param array    $block         The full block, including name and attributes.
- * @param WP_Block $instance      The block instance.
+ * @param array $parsed_block The parsed block array (name, attrs, innerBlocks, innerContent, innerHTML).
  *
- * @return string The modified block content.
+ * @return array The (possibly shuffled) parsed block.
  */
-function blocks_randomizer_list_render_callback( $block_content, $block, $instance ) {
-	// Only process core/list blocks.
-	if ( 'core/list' !== $block['blockName'] ) {
-		return $block_content;
+function blocks_randomizer_list_shuffle_items( $parsed_block ) {
+	if ( 'core/list' !== $parsed_block['blockName'] ) {
+		return $parsed_block;
 	}
 
-	// Check if randomize attribute is enabled.
-	$randomize = isset( $block['attrs']['randomize'] ) && $block['attrs']['randomize'];
-
-	if ( ! $randomize ) {
-		return $block_content;
+	if ( empty( $parsed_block['attrs']['randomize'] ) ) {
+		return $parsed_block;
 	}
 
-	// Parse the HTML content to find list items.
-	// Note: The block content comes from the WordPress database and has already been
-	// sanitized during block saving, so it's safe to parse here.
-	$dom = new DOMDocument();
-	// Suppress warnings for malformed HTML.
-	libxml_use_internal_errors( true );
-	
-	// Load HTML with UTF-8 encoding.
-	$dom->loadHTML( '<?xml encoding="UTF-8">' . $block_content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-	
-	// Clear any errors.
-	libxml_clear_errors();
-
-	// Find the list element (ul or ol).
-	$xpath = new DOMXPath( $dom );
-	$lists = $xpath->query( '//ul | //ol' );
-
-	if ( $lists->length === 0 ) {
-		return $block_content;
+	if ( ! empty( $parsed_block['innerBlocks'] ) && count( $parsed_block['innerBlocks'] ) > 1 ) {
+		shuffle( $parsed_block['innerBlocks'] );
 	}
 
-	// Process each list (usually just one).
-	foreach ( $lists as $list ) {
-		// Get all direct li children.
-		$list_items = array();
-		foreach ( $list->childNodes as $child ) {
-			if ( $child->nodeType === XML_ELEMENT_NODE && $child->nodeName === 'li' ) {
-				$list_items[] = $child;
-			}
-		}
-
-		// If we have list items, randomize them.
-		if ( count( $list_items ) > 1 ) {
-			// Remove all list items from the list.
-			foreach ( $list_items as $item ) {
-				$list->removeChild( $item );
-			}
-
-			// Shuffle the list items array.
-			shuffle( $list_items );
-
-			// Re-append the list items in random order.
-			foreach ( $list_items as $item ) {
-				$list->appendChild( $item );
-			}
-		}
-	}
-
-	// Save the modified HTML.
-	$modified_content = $dom->saveHTML();
-	
-	// Remove the XML encoding declaration that was added.
-	$modified_content = str_replace( '<?xml encoding="UTF-8">', '', $modified_content );
-
-	return $modified_content;
+	return $parsed_block;
 }
 
-add_filter( 'render_block', 'blocks_randomizer_list_render_callback', 10, 3 );
+add_filter( 'render_block_data', 'blocks_randomizer_list_shuffle_items' );


### PR DESCRIPTION
Supersedes #14. Implements issue #6 (Randomize toggle on `core/list`) with a simpler, more idiomatic approach after reviewing the original PR.

## What changed vs. PR #14

**Architecture**
- `block.json` no longer pretends this is a real block in the inserter. Added `supports.inserter: false` and removed the misleading `"render": "file:./render.php"` (render.php never defined a render callback — it only registered a `render_block` filter).
- Dropped the `saveRandomizeAttribute` filter and the `data-randomize="true"` HTML attribute it injected. The server reads `$block['attrs']['randomize']` from block delimiters, so the extra DOM attribute was dead code that only leaked into the frontend markup.

**Server-side rendering**
- Replaced ~90 lines of `DOMDocument` + `DOMXPath` HTML parsing with a 10-line `render_block_data` filter that shuffles `$parsed_block['innerBlocks']` before WordPress renders them. The modern (v2) `core/list` block stores list items as inner `core/list-item` blocks, so reordering the array is enough — WordPress walks `innerContent` null-placeholders in order.
- Fixes a latent bug where the previous XPath `//ul | //ol` also shuffled every **nested** sublist when the parent had randomize enabled.
- Eliminates the `<?xml encoding="UTF-8">` hack, libxml error suppression, and `saveHTML()` post-processing.

**Other cleanup**
- Removed `checked={ randomize || false }` redundancy (attribute default is already `false`).
- Reverted unrelated `"peer": true` churn in `package-lock.json`.
- Updated the toggle help text to be honest about caching: "with full-page caching the order changes only when the cache is regenerated" (the previous PR description claimed "compatible with caching" without the caveat).

## Diff

| File | Before (PR #14) | After |
|---|---|---|
| `src/list-randomizer/render.php` | 92 lines (DOMDocument) | 37 lines (`render_block_data`) |
| `src/list-randomizer/index.js` | 112 lines (3 filters) | 74 lines (2 filters) |
| `src/list-randomizer/block.json` | registered as real block | `supports.inserter: false`, no `render` |
| `package-lock.json` | 6 lines removed | unchanged vs. main |

Net: **+34 / −118** across 4 files.

## Known limitation

The `render_block_data`/innerBlocks approach only works for the modern (v2) list block where items are inner blocks. Legacy v1 lists (inline `<li>` in `innerHTML`) won't shuffle. Given the plugin requires WP 6.7+, that's acceptable — users can migrate the block in the editor.

## Follow-ups (not in this PR)

Issue #6 also mentions Columns and Media & Text. This PR covers List only, matching the original "start with List" prompt. A `block-extensions/` folder pattern could be extracted if/when those are added, so the scaffolding is reused instead of duplicated.

Closes #14. Refs #6.